### PR TITLE
Temporarily use an older git commit of validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 install: 
-  - git clone --depth 1 -q https://github.com/MassBank/MassBank-web.git .scripts/MassBank-web
+  - git clone -q https://github.com/MassBank/MassBank-web.git .scripts/MassBank-web
+  - ( cd .scripts/MassBank-web ; git checkout 0e47e5ec20918b7d41583e4e907a7eb1eb0878d8 )
   - mvn -q -f .scripts/MassBank-web/MassBank-Project/MassBank-lib/pom.xml install
   - tar -xvjf .scripts/libinchi.tar.bz -C ~
 script: 


### PR DESCRIPTION
Use 0e47e5ec20918b7d41583e4e907a7eb1eb0878d8 which is the last commit passing travis,
revert this change when https://github.com/MassBank/MassBank-web/issues/109 is fixed. Yours, Steffen